### PR TITLE
Add OPENSSL_armcap_P to indirect symbols to fix IOS 8 compilation issue

### DIFF
--- a/crypto/armv4cpuid.pl
+++ b/crypto/armv4cpuid.pl
@@ -211,10 +211,21 @@ _armv8_pmull_probe:
 .type	OPENSSL_wipe_cpu,%function
 OPENSSL_wipe_cpu:
 #if __ARM_MAX_ARCH__>=7
+
+# ifdef __APPLE__ 
+	movw r0, :lower16:(.LOPENSSL_armcap-(LPC0_0+4))
+	movt r0, :upper16:(.LOPENSSL_armcap-(LPC0_0+4))
+LPC0_0:
+	add	r0, pc
+	ldr r0, [r0]
+# else
 	ldr	r0,.LOPENSSL_armcap
+# endif
+
+# ifndef	__APPLE__
 	adr	r1,.LOPENSSL_armcap
 	ldr	r0,[r1,r0]
-#ifdef	__APPLE__
+# else
 	ldr	r0,[r0]
 #endif
 #endif
@@ -274,10 +285,23 @@ OPENSSL_instrument_bus2:
 #endif
 .size	OPENSSL_instrument_bus2,.-OPENSSL_instrument_bus2
 
+
+
+# ifdef __APPLE__ 
+.section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers @ if its apple then it needs to be in a special section
+.p2align	2
+# endif
+
 .align	5
 #if __ARM_MAX_ARCH__>=7
 .LOPENSSL_armcap:
+# ifdef __APPLE__
+.indirect_symbol	_OPENSSL_armcap_P
+.long	0
+.text @ The rest of the content should be in the text section
+# else
 .word	OPENSSL_armcap_P-.
+# endif
 #endif
 #if __ARM_ARCH__>=6
 .align	5

--- a/crypto/armv4cpuid.pl
+++ b/crypto/armv4cpuid.pl
@@ -211,7 +211,6 @@ _armv8_pmull_probe:
 .type	OPENSSL_wipe_cpu,%function
 OPENSSL_wipe_cpu:
 #if __ARM_MAX_ARCH__>=7
-
 # ifdef __APPLE__ 
 	movw r0, :lower16:(.LOPENSSL_armcap-(LPC0_0+4))
 	movt r0, :upper16:(.LOPENSSL_armcap-(LPC0_0+4))
@@ -221,7 +220,6 @@ LPC0_0:
 # else
 	ldr	r0,.LOPENSSL_armcap
 # endif
-
 # ifndef	__APPLE__
 	adr	r1,.LOPENSSL_armcap
 	ldr	r0,[r1,r0]
@@ -285,13 +283,10 @@ OPENSSL_instrument_bus2:
 #endif
 .size	OPENSSL_instrument_bus2,.-OPENSSL_instrument_bus2
 
-
-
 # ifdef __APPLE__ 
 .section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers @ if its apple then it needs to be in a special section
 .p2align	2
 # endif
-
 .align	5
 #if __ARM_MAX_ARCH__>=7
 .LOPENSSL_armcap:

--- a/crypto/bn/asm/armv4-gf2m.pl
+++ b/crypto/bn/asm/armv4-gf2m.pl
@@ -187,7 +187,6 @@ LPC0_0:
 # else 
 	ldr	r12,.LOPENSSL_armcap
 # endif
-
 # if !defined(_WIN32) && !defined(__APPLE__)
 	adr	r10,.LOPENSSL_armcap
 	ldr	r12,[r12,r10]
@@ -322,12 +321,10 @@ $code.=<<___;
 .size	bn_GF2m_mul_2x2,.-bn_GF2m_mul_2x2
 #if __ARM_MAX_ARCH__>=7
 .align	5
-
-#ifdef __APPLE__ 
+# ifdef __APPLE__ 
 .section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers @ if its apple then it needs to be in a special section
 .p2align	2
-#endif
-
+# endif
 .LOPENSSL_armcap:
 # ifdef	_WIN32
 .word	OPENSSL_armcap_P

--- a/crypto/bn/asm/armv4-gf2m.pl
+++ b/crypto/bn/asm/armv4-gf2m.pl
@@ -178,12 +178,20 @@ $code.=<<___;
 bn_GF2m_mul_2x2:
 #if __ARM_MAX_ARCH__>=7
 	stmdb	sp!,{r10,lr}
+# ifdef __APPLE__
+	movw r12, :lower16:(.LOPENSSL_armcap-(LPC0_0+4))
+	movt r12, :upper16:(.LOPENSSL_armcap-(LPC0_0+4))
+LPC0_0:
+	add	r12, pc
+	ldr r12, [r12]
+# else 
 	ldr	r12,.LOPENSSL_armcap
-# if !defined(_WIN32)
+# endif
+
+# if !defined(_WIN32) && !defined(__APPLE__)
 	adr	r10,.LOPENSSL_armcap
 	ldr	r12,[r12,r10]
-# endif
-# if defined(__APPLE__) || defined(_WIN32)
+# else
 	ldr	r12,[r12]
 # endif
 	tst	r12,#ARMV7_NEON
@@ -314,10 +322,20 @@ $code.=<<___;
 .size	bn_GF2m_mul_2x2,.-bn_GF2m_mul_2x2
 #if __ARM_MAX_ARCH__>=7
 .align	5
+
+#ifdef __APPLE__ 
+.section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers @ if its apple then it needs to be in a special section
+.p2align	2
+#endif
+
 .LOPENSSL_armcap:
 # ifdef	_WIN32
 .word	OPENSSL_armcap_P
-# else
+# elif defined(__APPLE__)
+.indirect_symbol	_OPENSSL_armcap_P
+.long	0
+.text @ The rest of the content should be in the text section
+# else 
 .word	OPENSSL_armcap_P-.
 # endif
 #endif

--- a/crypto/bn/asm/armv4-mont.pl
+++ b/crypto/bn/asm/armv4-mont.pl
@@ -108,12 +108,11 @@ $code=<<___;
 
 .text
 
-#ifdef __APPLE__ 
+#if __ARM_MAX_ARCH__>=7
+# ifdef __APPLE__ 
 .section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers @ if its apple then it needs to be in a special section
 .p2align	2
-#endif
-
-#if __ARM_MAX_ARCH__>=7
+# endif
 .align	5
 .LOPENSSL_armcap:
 # if	defined(_WIN32)
@@ -148,7 +147,6 @@ LPC0_0:
 # else
 	ldr	r0,.LOPENSSL_armcap
 # endif
-
 # if !defined(_WIN32) && !defined(__APPLE__)
 	adr	r2,.Lbn_mul_mont
 	ldr	r0,[r0,r2]

--- a/crypto/bn/asm/armv4-mont.pl
+++ b/crypto/bn/asm/armv4-mont.pl
@@ -137,7 +137,6 @@ bn_mul_mont:
 #if __ARM_MAX_ARCH__>=7
 	tst	ip,#7
 	bne	.Lialu
-
 # ifdef __APPLE__
 	movw r0, :lower16:(.LOPENSSL_armcap-(LPC0_0+4))
 	movt r0, :upper16:(.LOPENSSL_armcap-(LPC0_0+4))

--- a/crypto/chacha/asm/chacha-armv4.pl
+++ b/crypto/chacha/asm/chacha-armv4.pl
@@ -194,12 +194,10 @@ $code.=<<___;
 .Lone:
 .long	1,0,0,0
 #if __ARM_MAX_ARCH__>=7
-
 # ifdef __APPLE__ 
 .section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers @ if its apple then it needs to be in a special section
 .p2align	2
 # endif
-
 .LOPENSSL_armcap:
 # if defined(_WIN32)
 .word	OPENSSL_armcap_P

--- a/crypto/poly1305/asm/poly1305-armv4.pl
+++ b/crypto/poly1305/asm/poly1305-armv4.pl
@@ -77,16 +77,12 @@ poly1305_init:
 	str	r3,[$ctx,#16]
 	str	r3,[$ctx,#36]		@ is_base2_26
 	add	$ctx,$ctx,#20
-
 #ifdef	__thumb2__
 	it	eq
 #endif
 	moveq	r0,#0
 	beq	.Lno_key
-
 #if	__ARM_MAX_ARCH__>=7
-
-
 # ifdef __APPLE__ 
 	movw r12, :lower16:(.LOPENSSL_armcap-(LPC0_0+4))
 	movt r12, :upper16:(.LOPENSSL_armcap-(LPC0_0+4))

--- a/crypto/poly1305/asm/poly1305-armv4.pl
+++ b/crypto/poly1305/asm/poly1305-armv4.pl
@@ -1231,12 +1231,10 @@ poly1305_emit_neon:
 .align	5
 .Lzeros:
 .long	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-
 # ifdef __APPLE__ 
 .section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers @ if its apple then it needs to be in a special section
 .p2align	2
 # endif
-
 .LOPENSSL_armcap:
 # if	defined(_WIN32)
 .word	OPENSSL_armcap_P

--- a/crypto/sha/asm/sha1-armv4-large.pl
+++ b/crypto/sha/asm/sha1-armv4-large.pl
@@ -205,7 +205,6 @@ $code=<<___;
 sha1_block_data_order:
 #if __ARM_MAX_ARCH__>=7
 .Lsha1_block:
-
 # ifdef __APPLE__
 	movw r12, :lower16:(.LOPENSSL_armcap-(LPC0_0+4))
 	movt r12, :upper16:(.LOPENSSL_armcap-(LPC0_0+4))
@@ -323,15 +322,11 @@ $code.=<<___;
 .LK_40_59:	.word	0x8f1bbcdc
 .LK_60_79:	.word	0xca62c1d6
 
-
-
 #if __ARM_MAX_ARCH__>=7
-
 # ifdef __APPLE__ 
 .section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers @ if its apple then it needs to be in a special section
 .p2align	2
 # endif
-
 .LOPENSSL_armcap:
 # if	defined(_WIN32)
 .word	OPENSSL_armcap_P

--- a/crypto/sha/asm/sha1-armv4-large.pl
+++ b/crypto/sha/asm/sha1-armv4-large.pl
@@ -321,7 +321,6 @@ $code.=<<___;
 .LK_20_39:	.word	0x6ed9eba1
 .LK_40_59:	.word	0x8f1bbcdc
 .LK_60_79:	.word	0xca62c1d6
-
 #if __ARM_MAX_ARCH__>=7
 # ifdef __APPLE__ 
 .section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers @ if its apple then it needs to be in a special section

--- a/crypto/sha/asm/sha1-armv4-large.pl
+++ b/crypto/sha/asm/sha1-armv4-large.pl
@@ -205,12 +205,20 @@ $code=<<___;
 sha1_block_data_order:
 #if __ARM_MAX_ARCH__>=7
 .Lsha1_block:
+
+# ifdef __APPLE__
+	movw r12, :lower16:(.LOPENSSL_armcap-(LPC0_0+4))
+	movt r12, :upper16:(.LOPENSSL_armcap-(LPC0_0+4))
+LPC0_0:
+	add	r12, pc
+	ldr r12, [r12]
+# else 
 	ldr	r12,.LOPENSSL_armcap
-# if !defined(_WIN32)
+# endif
+# if !defined(_WIN32) && !defined(__APPLE__)
 	adr	r3,.Lsha1_block
 	ldr	r12,[r3,r12]		@ OPENSSL_armcap_P
-# endif
-# if defined(__APPLE__) || defined(_WIN32)
+# else
 	ldr	r12,[r12]
 # endif
 	tst	r12,#ARMV8_SHA1
@@ -314,10 +322,23 @@ $code.=<<___;
 .LK_20_39:	.word	0x6ed9eba1
 .LK_40_59:	.word	0x8f1bbcdc
 .LK_60_79:	.word	0xca62c1d6
+
+
+
 #if __ARM_MAX_ARCH__>=7
+
+# ifdef __APPLE__ 
+.section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers @ if its apple then it needs to be in a special section
+.p2align	2
+# endif
+
 .LOPENSSL_armcap:
-# ifdef	_WIN32
+# if	defined(_WIN32)
 .word	OPENSSL_armcap_P
+# elif defined(__APPLE__)
+.indirect_symbol	_OPENSSL_armcap_P
+.long	0
+.text @ The rest of the content should be in the text section
 # else
 .word	OPENSSL_armcap_P-.Lsha1_block
 # endif

--- a/crypto/sha/asm/sha256-armv4.pl
+++ b/crypto/sha/asm/sha256-armv4.pl
@@ -215,12 +215,10 @@ K256:
 .word	0				@ terminator
 
 #if __ARM_MAX_ARCH__>=7 && !defined(__KERNEL__)
-
 # ifdef __APPLE__ 
 .section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers @ if its apple then it needs to be in a special section
 .p2align	2
 # endif
-
 .LOPENSSL_armcap:
 # if	defined(_WIN32)
 .word	OPENSSL_armcap_P

--- a/crypto/sha/asm/sha256-armv4.pl
+++ b/crypto/sha/asm/sha256-armv4.pl
@@ -213,7 +213,6 @@ K256:
 .word	0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
 .size	K256,.-K256
 .word	0				@ terminator
-
 #if __ARM_MAX_ARCH__>=7 && !defined(__KERNEL__)
 # ifdef __APPLE__ 
 .section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers @ if its apple then it needs to be in a special section

--- a/crypto/sha/asm/sha512-armv4.pl
+++ b/crypto/sha/asm/sha512-armv4.pl
@@ -278,12 +278,10 @@ WORD64(0x4cc5d4be,0xcb3e42b6, 0x597f299c,0xfc657e2a)
 WORD64(0x5fcb6fab,0x3ad6faec, 0x6c44198c,0x4a475817)
 .size	K512,.-K512
 #if __ARM_MAX_ARCH__>=7 && !defined(__KERNEL__)
-
 # ifdef __APPLE__ 
 .section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers @ if its apple then it needs to be in a special section
 .p2align	2
 # endif
-
 .LOPENSSL_armcap:
 # if	defined(_WIN32)
 .word	OPENSSL_armcap_P


### PR DESCRIPTION
The following PR addresses #26510 

I've spent some time looking into this and it seems to be a limitation of the Mach-O format based on compiler/linker code. 

Looking in the LLVM source code, whenever we have a difference between two symbols it hits `ARMMachObjectWriter::recordARMScatteredRelocation`. The call for this can be found [here](https://github.com/llvm/llvm-project/blob/52fc6ffcda0895c0c7b976ad1f5cb5a282b571d2/llvm/lib/Target/ARM/MCTargetDesc/ARMMachObjectWriter.cpp#L375). In `ARMMachObjectWriter::recordARMScatteredRelocation`, we get the address associated with both symbols and we create a `ARM_RELOC_SECTDIFF` entry that the mach-o linker will relocate. The subtraction expression error can also be found [here](https://github.com/llvm/llvm-project/blob/52fc6ffcda0895c0c7b976ad1f5cb5a282b571d2/llvm/lib/Target/ARM/MCTargetDesc/ARMMachObjectWriter.cpp#L279). 

Now, interestingly, according to some [comments](https://github.com/apple-oss-distributions/cctools/blob/3406a8e0f9ec28862967217797fe2b9a7b3d10ed/ld/arm_reloc.c#L1381) in apple's `ld`, we see that  `ARM_RELOC_SECTDIFF` are always scattered. 

Looking at some more [code](https://github.com/apple-oss-distributions/cctools/blob/main/include/mach-o/reloc.h#L151) in apple's compiler code, we see that a scattered relocation entry has value instead of a symbol index. So, it seems we need to always have concrete values instead of undefined symbols. 

TL;DR, the Mach-O format for ARMv7 has a key limitation where it seems it cannot use undefined symbols in a subtraction due to how its relocations function. 

We also cannot introduce a simple extern symbol as the linker also rejects that.

It seems, after some investigation using clang's `-S` feature, the proper way to do something like this is to introduce the symbol into an `__nl_symbol_ptr` section and use a relative addressing scheme to get the value of the symbol pointer.  

This PR introduces apple-specific code to put the `OPENSSL_armcap_P` in a `__nl_symbol_ptr` section instead of putting it in the `.text` section. 

Tagging: @bbbrumley 
Tagging: @cjf7669